### PR TITLE
Prepare `XCGradleHarness` for `NonisolatedNonsendingByDefault`

### DIFF
--- a/Sources/SkipTest/XCGradleHarness.swift
+++ b/Sources/SkipTest/XCGradleHarness.swift
@@ -61,7 +61,7 @@ extension XCGradleHarness where Self : XCTestCase {
     ///   - sourcePath: the full path to the test case call site, which is used to determine the package root
     @available(macOS 13, macCatalyst 16, iOS 16, tvOS 16, watchOS 8, *)
     nonisolated(nonsending)
-    func invokeGradle(actions: [String], arguments: [String] = [], info: Bool = false, deviceID: String? = nil, testFilter: String? = nil, moduleName: String? = nil, maxMemory: UInt64? = ProcessInfo.processInfo.physicalMemory, fromSourceFileRelativeToPackageRoot sourcePath: StaticString? = #file) async throws {
+    func invokeGradle(actions: [String], arguments: [String] = [], info: Bool = false, deviceID: String? = nil, testFilters: [String]? = nil, moduleName: String? = nil, maxMemory: UInt64? = ProcessInfo.processInfo.physicalMemory, fromSourceFileRelativeToPackageRoot sourcePath: StaticString? = #file) async throws {
         var actions = actions
         let isTestAction = actions.contains(where: { $0.hasPrefix("test") || $0.hasPrefix("connected") })
 

--- a/Sources/SkipTest/XCGradleHarness.swift
+++ b/Sources/SkipTest/XCGradleHarness.swift
@@ -24,6 +24,7 @@ extension XCGradleHarness where Self : XCTestCase {
     ///
     /// - SeeAlso: https://developer.android.com/studio/test/command-line
     /// - SeeAlso: https://docs.gradle.org/current/userguide/java_testing.html#test_filtering
+    nonisolated(nonsending)
     public func runGradleTests(device: String? = ProcessInfo.processInfo.environment["ANDROID_SERIAL"], file: StaticString = #file, line: UInt = #line) async throws {
         do {
             #if DEBUG
@@ -50,6 +51,7 @@ extension XCGradleHarness where Self : XCTestCase {
     ///   - moduleSuffix: the expected module name for automatic test determination
     ///   - sourcePath: the full path to the test case call site, which is used to determine the package root
     @available(macOS 13, macCatalyst 16, iOS 16, tvOS 16, watchOS 8, *)
+    nonisolated(nonsending)
     func invokeGradle(actions: [String], arguments: [String] = [], info: Bool = false, deviceID: String? = nil, testFilter: String? = nil, moduleName: String? = nil, maxMemory: UInt64? = ProcessInfo.processInfo.physicalMemory, fromSourceFileRelativeToPackageRoot sourcePath: StaticString? = #file) async throws {
 
         // the filters should be passed through to the --tests argument, but they don't seem to work for Android unit tests, neighter for Robolectric nor connected tests

--- a/Sources/SkipTest/XCGradleHarness.swift
+++ b/Sources/SkipTest/XCGradleHarness.swift
@@ -61,7 +61,7 @@ extension XCGradleHarness where Self : XCTestCase {
     ///   - sourcePath: the full path to the test case call site, which is used to determine the package root
     @available(macOS 13, macCatalyst 16, iOS 16, tvOS 16, watchOS 8, *)
     nonisolated(nonsending)
-    func invokeGradle(actions: [String], arguments: [String] = [], info: Bool = false, deviceID: String? = nil, testFilters: [String]? = nil, moduleName: String? = nil, maxMemory: UInt64? = ProcessInfo.processInfo.physicalMemory, fromSourceFileRelativeToPackageRoot sourcePath: StaticString? = #file) async throws {
+    func invokeGradle(actions: [String], arguments: [String] = [], info: Bool = false, deviceID: String? = nil, testFilters: [String] = [], moduleName: String? = nil, maxMemory: UInt64? = ProcessInfo.processInfo.physicalMemory, fromSourceFileRelativeToPackageRoot sourcePath: StaticString? = #file) async throws {
         var actions = actions
         let isTestAction = actions.contains(where: { $0.hasPrefix("test") || $0.hasPrefix("connected") })
 


### PR DESCRIPTION
Fixes #675

The issue occurred because the `skip` project is built without `NonisolatedNonsendingByDefault`, which means that `runGradleTests` and `invokeGradle` were `@concurrent` by legacy default, forbidden to access `self` or any `task-isolated` members.

The generated `XCSkipTests` file in the end-user's project, however, _is_ `NonisolatedNonsendingByDefault` on Swift 6.2, which means that `testSkipModule` method became task-isolated. (I'm a little unclear on how/why the test became task-isolated, but it did.)

We could have fixed this by updating `skip` to Swift 6.2+ and enabling `NonisolatedNonsendingByDefault` and other "Approachable Concurrency" features there, but this is easier, and will continue to work if/when we upgrade `skip` in the future. (When `skip` does decide to enable `NonisolatedNonsendingByDefault`, these annotations will simply reiterate the default.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

