### PR TITLE
Tolerate Gradle symlink creation race condition

### DIFF
--- a/Sources/SkipDrive/GradleHarness.swift
+++ b/Sources/SkipDrive/GradleHarness.swift
@@ -83,7 +83,16 @@ extension GradleHarness {
                         let linkFrom = localModuleLink.path, linkTo = outputFolder.path
                         if (try? FileManager.default.destinationOfSymbolicLink(atPath: linkFrom)) != linkTo {
                             try? FileManager.default.removeItem(atPath: linkFrom) // if it exists
-                            try FileManager.default.createSymbolicLink(atPath: linkFrom, withDestinationPath: linkTo)
+                            do {
+                                try FileManager.default.createSymbolicLink(atPath: linkFrom, withDestinationPath: linkTo)
+                            } catch {
+                                // Concurrent test targets in the same package race to create the same symlink
+                                // (same linkFrom, same linkTo). If another target won the race, the link will
+                                // already point where we want — treat that as success.
+                                if (try? FileManager.default.destinationOfSymbolicLink(atPath: linkFrom)) != linkTo {
+                                    throw error
+                                }
+                            }
                         }
 
                         let localTranspilerOut = URL(fileURLWithPath: outputFolder.lastPathComponent, isDirectory: true, relativeTo: localModuleLink)


### PR DESCRIPTION
When running `skip test`, we sometimes see failures like: 

```
[✗] …/SkipTestHarness/XCSkipTests.swift:10: error: -[XCSkipTests testSkipModule] : failed - The file “skipapp-hiya” couldn’t be saved in the folder “build” because a file with the same name already exists.
```

Re-running the tests almost always results in them passing. The speculated cause is because `skip test` runs tests in parallel, multiple builds might be simultaneously be trying to create a symlink to the same destination when they see it doesn't exist.

This PR tolerates failed attempts to create the symlink, provided that the symlink is pointing to the expected destination.